### PR TITLE
Close issue when GitHub release is published

### DIFF
--- a/.github/workflows/git-issue-release.yml
+++ b/.github/workflows/git-issue-release.yml
@@ -3,6 +3,8 @@ name: git-issue-release
 on:
   pull_request:
     types: [closed]
+  release:
+    types: [published]
 
 jobs:
   action:

--- a/action.yml
+++ b/action.yml
@@ -2,7 +2,7 @@ name: 'git-issue-release'
 description: 'Automatically generate PRs diff from previous release'
 inputs:
   release-tag-prefix:
-    description: 'Prefix of release tag'
+    description: "Prefix of release tag. It is used to link GitHub Releases and release Issues (not needed if you don't use automatic closing when release is published)"
     required: true
     default: 'v'
   release-label:

--- a/git-issue-release.test.ts
+++ b/git-issue-release.test.ts
@@ -23,7 +23,9 @@ test("should create when release issue has not been cretaed", async () => {
   jest
     .spyOn(lib, "findOpenReleaseIssue")
     .mockReturnValue(Promise.resolve(null));
-  jest.spyOn(lib, "closeReleasedIssue").mockReturnValue(Promise.resolve());
+  jest
+    .spyOn(lib, "closeReleasedIssueIfNeeded")
+    .mockReturnValue(Promise.resolve(true));
 
   const spyCreateReleaseIssue = jest.spyOn(lib, "createReleaseIssue");
   spyCreateReleaseIssue.mockReturnValue(Promise.resolve({ number: 1 }));
@@ -54,7 +56,9 @@ test("Should update when release issue has been created", async () => {
       number: 1,
     })
   );
-  jest.spyOn(lib, "closeReleasedIssue").mockReturnValue(Promise.resolve());
+  jest
+    .spyOn(lib, "closeReleasedIssueIfNeeded")
+    .mockReturnValue(Promise.resolve(true));
 
   const spyUpdateReleaseIssue = jest.spyOn(lib, "updateReleaseIssue");
   spyUpdateReleaseIssue.mockReturnValue(Promise.resolve());

--- a/git-issue-release.test.ts
+++ b/git-issue-release.test.ts
@@ -23,6 +23,7 @@ test("should create when release issue has not been cretaed", async () => {
   jest
     .spyOn(lib, "findOpenReleaseIssue")
     .mockReturnValue(Promise.resolve(null));
+  jest.spyOn(lib, "closeReleasedIssue").mockReturnValue(Promise.resolve());
 
   const spyCreateReleaseIssue = jest.spyOn(lib, "createReleaseIssue");
   spyCreateReleaseIssue.mockReturnValue(Promise.resolve({ number: 1 }));
@@ -53,6 +54,7 @@ test("Should update when release issue has been created", async () => {
       number: 1,
     })
   );
+  jest.spyOn(lib, "closeReleasedIssue").mockReturnValue(Promise.resolve());
 
   const spyUpdateReleaseIssue = jest.spyOn(lib, "updateReleaseIssue");
   spyUpdateReleaseIssue.mockReturnValue(Promise.resolve());

--- a/git-issue-release.ts
+++ b/git-issue-release.ts
@@ -76,10 +76,11 @@ export async function gitIssueRelease() {
     !github.context.payload["release"]["prerelease"]
   ) {
     const tag_name = github.context.payload["release"]["tag_name"];
-    await lib.closeReleasedIssue(
+    await lib.closeReleasedIssueIfNeeded(
       owner,
       repo,
       release_labels,
+      release_tag_prefix,
       tag_name,
       octokit
     );

--- a/git-issue-release.ts
+++ b/git-issue-release.ts
@@ -23,11 +23,15 @@ export async function gitIssueRelease() {
 
   let head_commitish: string;
   if (github.context.payload["pull_request"]) {
+    // Pull Request
     head_commitish = github.context.payload["pull_request"]["merge_commit_sha"];
   } else if (github.context.payload["head_commit"]) {
+    // Push
     head_commitish = github.context.payload["head_commit"]["id"];
+  } else if (github.context.payload["release"]) {
+    // Release
+    head_commitish = github.context.payload["release"]["tag_name"];
   } else {
-    // TODO: add case of publishing a tag
     head_commitish = "";
     console.warn("faild to find head commit");
   }
@@ -67,13 +71,15 @@ export async function gitIssueRelease() {
     );
   }
 
-  if (github.context.payload["action"] == "released") {
+  if (
+    github.context.payload["action"] === "published" &&
+    !github.context.payload["release"]["prerelease"]
+  ) {
     const tag_name = github.context.payload["release"]["tag_name"];
-    await lib.closeReleasedIssueIfNeeded(
+    await lib.closeReleasedIssue(
       owner,
       repo,
       release_labels,
-      release_tag_prefix,
       tag_name,
       octokit
     );

--- a/lib.test.ts
+++ b/lib.test.ts
@@ -223,11 +223,16 @@ describe("createReleaseIssue", () => {
 });
 
 test("closeReleasedIssueIfNeeded", () => {
-  return lib.closeReleasedIssueIfNeeded(
+  octokit.rest = {
+    issues: {
+      createComment: jest.fn(),
+      update: jest.fn(),
+    },
+  };
+  return lib.closeReleasedIssue(
     "owner",
     "repo",
     ["Release"],
-    "v",
     "v1.0.0",
     octokit
   );

--- a/lib.test.ts
+++ b/lib.test.ts
@@ -229,13 +229,27 @@ test("closeReleasedIssueIfNeeded", () => {
       update: jest.fn(),
     },
   };
-  return lib.closeReleasedIssue(
-    "owner",
-    "repo",
-    ["Release"],
-    "v1.0.0",
-    octokit
-  );
+  expect(
+    lib.closeReleasedIssueIfNeeded(
+      "owner",
+      "repo",
+      ["Release"],
+      "v",
+      "v1.0.0",
+      octokit
+    )
+  ).resolves.toBe(true);
+
+  expect(
+    lib.closeReleasedIssueIfNeeded(
+      "owner",
+      "repo",
+      ["Release"],
+      "v",
+      "1.0.0",
+      octokit
+    )
+  ).resolves.toBe(false);
 });
 
 test("parseReleaseLabel", () => {

--- a/lib.ts
+++ b/lib.ts
@@ -123,13 +123,17 @@ export async function createReleaseIssue(
   return created_issue.data;
 }
 
-export async function closeReleasedIssue(
+export async function closeReleasedIssueIfNeeded(
   owner: string,
   repo: string,
   release_labels: string[],
+  tag_prefix: string,
   released_tag_name: string,
   octokit: Octokit
-): Promise<void> {
+): Promise<boolean> {
+  if (!released_tag_name.startsWith(tag_prefix)) {
+    return false;
+  }
   const latest_open_release_issue = await findOpenReleaseIssue(
     owner,
     repo,
@@ -138,7 +142,7 @@ export async function closeReleasedIssue(
   );
   if (latest_open_release_issue === null) {
     console.warn("Cannot find a open release issue");
-    return;
+    return false;
   }
 
   const html_url = `https://github.com/{owner}/{repo}/releases/tag/{released_tag_name}`;
@@ -156,6 +160,7 @@ export async function closeReleasedIssue(
     issue_number: latest_open_release_issue.number,
     state: "closed",
   });
+  return true;
 }
 
 export function parseReleaseLabel(release_label: string): string[] {

--- a/lib.ts
+++ b/lib.ts
@@ -141,7 +141,7 @@ export async function closeReleasedIssueIfNeeded(
     octokit
   );
   if (latest_open_release_issue === null) {
-    console.warn("Cannot find a open release issue");
+    console.warn("Could not find a open release issue");
     return false;
   }
 


### PR DESCRIPTION
https://docs.github.com/en/actions/learn-github-actions/events-that-trigger-workflows#release
> Note: The prereleased type will not trigger for pre-releases published from draft releases, but the published type will trigger. If you want a workflow to run when stable and pre-releases publish, subscribe to published instead of released and prereleased.

