### PR TITLE
Set actions version as exact version

### DIFF
--- a/.github/workflows/git-issue-release.yml
+++ b/.github/workflows/git-issue-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: git-issue-release
-        uses: kouki-dan/git-issue-release@v0
+        uses: kouki-dan/git-issue-release@v0.1.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:


### PR DESCRIPTION
I thought the major version is automatically created but it is not created.

According to [this article](https://docs.github.com/en/actions/creating-actions/about-custom-actions#using-tags-for-release-management), the major tag is also just a git tag. I should create a tag and manually kept up to date.

I've not created a v0 tag, so `kouki-dan/git-issue-release@v0` is not found and failed it https://github.com/kouki-dan/git-issue-release/runs/4431602560?check_suite_focus=true

