### PR TITLE
Fix an issue when draft release exists

### DIFF
--- a/lib.ts
+++ b/lib.ts
@@ -23,6 +23,10 @@ export async function findLatestRelease(
     }
   )) {
     for (const release of response.data) {
+      if (release.draft) {
+        // tag_name of draft release does not exist in repository yet.
+        continue;
+      }
       if (new RegExp(tag_pattern).test(release.tag_name)) {
         if (skip <= 0) {
           return release;


### PR DESCRIPTION
tag_name of draft release does not exist in the repository yet. Using this tag_name, it fails to call the generating release note API. 