### PR TITLE
Add a new configuration-file-path parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,11 @@ Issue title after published. `:tag_name:` is replaced by a released tag name.
 
 An additional description for the release issue. It is inserted to the top of a body of an issue.
 
+
+## `configuration-file-path`
+
+Specifies a path to a file in the repository containing configuration settings used for generating the release notes. [More details](https://docs.github.com/en/rest/reference/releases#generate-release-notes-content-for-a-release).
+
 ## Example usage
 
 Full example: https://github.com/kouki-dan/git-issue-release/blob/main/.github/workflows/git-issue-release.yml

--- a/action.yml
+++ b/action.yml
@@ -21,6 +21,10 @@ inputs:
     description: "Additional description for release issue"
     required: false
     default: ""
+  configuration-file-path:
+    description: "Specifies a path to a file in the repository containing configuration settings used for generating the release notes."
+    required: false
+    default: ""
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/git-issue-release.ts
+++ b/git-issue-release.ts
@@ -7,6 +7,7 @@ export async function gitIssueRelease() {
   const release_labels = lib.parseReleaseLabel(core.getInput("release-label"));
   const issue_title = core.getInput("release-issue-title");
   const description = core.getInput("description");
+  const configuration_file_path = core.getInput("configuration-file-path");
   if (typeof process.env.GITHUB_TOKEN !== "string") {
     throw "GITHUB_TOKEN is required";
   }
@@ -49,6 +50,7 @@ export async function gitIssueRelease() {
     repo,
     head_commitish,
     previous_tag_name,
+    configuration_file_path,
     description,
     octokit
   );

--- a/lib.test.ts
+++ b/lib.test.ts
@@ -157,13 +157,22 @@ test("generateNotes", async () => {
       "repo",
       "head_commitish",
       "v1.0.0",
+      "",
       "description",
       octokit
     )
   ).resolves.toBe("description\ngenerated notes");
 
   await expect(
-    lib.generateNotes("owner", "repo", "head_commitish", "v1.0.0", "", octokit)
+    lib.generateNotes(
+      "owner",
+      "repo",
+      "head_commitish",
+      "v1.0.0",
+      "",
+      "",
+      octokit
+    )
   ).resolves.toBe("generated notes");
 });
 

--- a/lib.ts
+++ b/lib.ts
@@ -45,6 +45,7 @@ export async function generateNotes(
   repo: string,
   head_commitish: string,
   previous_tag_name: string | undefined,
+  configuration_file_path: string,
   description: string,
   octokit: Octokit
 ): Promise<string> {
@@ -56,6 +57,7 @@ export async function generateNotes(
       tag_name: head_commitish,
       target_commitish: head_commitish,
       previous_tag_name: previous_tag_name,
+      configuration_file_path: configuration_file_path,
     }
   );
   if (description) {


### PR DESCRIPTION
`configuration-file-path` passes the parameter of generate-notes API as `configuration_file_path`
https://docs.github.com/en/rest/reference/releases#generate-release-notes-content-for-a-release