### PR TITLE
Run closeReleasedIssueIfNeeded also on release is released

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ on:
   pull_request: # Automatically create or update issues when pull request is merged.
     types: [closed]
   release: # Automatically close the latest issue when release is published.
-    types: [published]
+    types: [released]
 
 jobs:
   action:

--- a/git-issue-release.ts
+++ b/git-issue-release.ts
@@ -83,8 +83,9 @@ export async function gitIssueRelease() {
   }
 
   if (
-    github.context.payload["action"] === "published" &&
-    !github.context.payload["release"]["prerelease"]
+    (github.context.payload["action"] === "published" &&
+      !github.context.payload["release"]["prerelease"]) ||
+    github.context.payload["action"] === "released"
   ) {
     const tag_name = github.context.payload["release"]["tag_name"];
     await lib.closeReleasedIssueIfNeeded(


### PR DESCRIPTION
In order to close the issue when a prerelease is changed to release, run
`closeReleasedIssueIfNeeded` also on `release.published` event.

c.f.
> published: a release, pre-release, or draft of a release is published
> released: a release or draft of a release is published, or a pre-release is changed to a release
> https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release


Thanks for this great GitHub Action! We are heavily depending on this!! 😄 