### PR TITLE
Fix using the type to find a publishing release

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8699,7 +8699,8 @@ function gitIssueRelease() {
         const { owner, repo } = github.context.repo;
         const latest_release = yield findLatestRelease(owner, repo, release_tag_pattern, octokit, {
             skip: github.context.payload.release &&
-                github.context.payload.action === "published"
+                (github.context.payload.action === "published" ||
+                    github.context.payload.action === "released")
                 ? 1
                 : 0,
         });

--- a/git-issue-release.ts
+++ b/git-issue-release.ts
@@ -41,7 +41,8 @@ export async function gitIssueRelease() {
     {
       skip:
         github.context.payload["release"] &&
-        github.context.payload["action"] === "published"
+        (github.context.payload["action"] === "published" ||
+          github.context.payload["action"] === "released")
           ? 1
           : 0,
     }


### PR DESCRIPTION
In case of using the `released` type, the latest release is the same as the own release when released.