### PR TITLE
Fix an unexpected body when PR is closed without merging

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -8708,6 +8708,10 @@ function gitIssueRelease() {
         let head_commitish;
         if (github.context.payload.pull_request) {
             // Pull Request
+            if (!github.context.payload.pull_request.merged) {
+                console.log("Skipped by pull Request is not merged yet.");
+                return;
+            }
             head_commitish = github.context.payload.pull_request.merge_commit_sha;
         }
         else if (github.context.payload.head_commit) {

--- a/git-issue-release.test.ts
+++ b/git-issue-release.test.ts
@@ -3,9 +3,30 @@ import * as core from "@actions/core";
 import * as lib from "./lib";
 import { gitIssueRelease } from "./git-issue-release";
 
+let originalContext = { ...github.context };
+
+afterEach(() => {
+  // Restore original @actions/github context
+  Object.defineProperty(github, "context", {
+    value: originalContext,
+  });
+});
+
 test("should create when release issue has not been cretaed", async () => {
   process.env.GITHUB_TOKEN = "token";
-  process.env.GITHUB_REPOSITORY = "owner/repo";
+  Object.defineProperty(github, "context", {
+    value: {
+      repo: {
+        owner: "owner",
+        repo: "repo",
+      },
+      payload: {
+        pull_request: {
+          merged: true,
+        },
+      },
+    },
+  });
   const octokit: any = {};
   jest.spyOn(github, "getOctokit").mockReturnValueOnce(octokit);
 
@@ -44,7 +65,20 @@ test("should create when release issue has not been cretaed", async () => {
 
 test("Should update when release issue has been created", async () => {
   process.env.GITHUB_TOKEN = "token";
-  process.env.GITHUB_REPOSITORY = "owner/repo";
+  Object.defineProperty(github, "context", {
+    value: {
+      repo: {
+        owner: "owner",
+        repo: "repo",
+      },
+      payload: {
+        pull_request: {
+          merged: true,
+        },
+      },
+    },
+  });
+
   const octokit: any = {};
   jest.spyOn(github, "getOctokit").mockReturnValueOnce(octokit);
 

--- a/git-issue-release.ts
+++ b/git-issue-release.ts
@@ -52,6 +52,10 @@ export async function gitIssueRelease() {
   let head_commitish: string;
   if (github.context.payload["pull_request"]) {
     // Pull Request
+    if (!github.context.payload["pull_request"]["merged"]) {
+      console.log("Skipped by pull Request is not merged yet.");
+      return;
+    }
     head_commitish = github.context.payload["pull_request"]["merge_commit_sha"];
   } else if (github.context.payload["head_commit"]) {
     // Push


### PR DESCRIPTION
See also #68 

Docs: https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-when-a-pull-request-merges

