### PR TITLE
Use push event in README

### DIFF
--- a/.github/workflows/git-issue-release.yml
+++ b/.github/workflows/git-issue-release.yml
@@ -1,8 +1,9 @@
 name: git-issue-release
 
 on:
-  pull_request:
-    types: [closed]
+  push:
+    branches:
+      - main
   release:
     types: [released]
 

--- a/README.md
+++ b/README.md
@@ -48,8 +48,9 @@ Full example: https://github.com/kouki-dan/git-issue-release/blob/main/.github/w
 name: git-issue-release
 
 on:
-  pull_request: # Automatically create or update issues when pull request is merged.
-    types: [closed]
+  push: # Automatically create or update issues when pull request is merged.
+    branches:
+      - main # Replace this with your main branch
   release: # Automatically close the latest issue when release is published.
     types: [released]
 


### PR DESCRIPTION
See #68

It only needs updating the documentation because the `push` event is supported already.
https://github.com/kouki-dan/git-issue-release/blob/6737537322383863c8e4ea00836e25e8e4c83532/git-issue-release.ts#L60-L62